### PR TITLE
feat: add `site_url` to prefix assets

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: TransitionZero Platform Docs
+site_url: ${BASE_URL}
 
 plugins:
     - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: TransitionZero Platform Docs
-site_url: ${BASE_URL}
+site_url: https://docs.feo.transitionzero.org/
 
 plugins:
     - search


### PR DESCRIPTION
### Description
To support assets (CSS, images, ...) to load properly for incoming rewrites to `docs.feo.transitionzero.org`, `site_url` allows specifying where to find those assets

### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
